### PR TITLE
fix: add full text index WITH PARSER NGRAM

### DIFF
--- a/sequelize/migrations/20221210033429-add_index.js
+++ b/sequelize/migrations/20221210033429-add_index.js
@@ -3,9 +3,9 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addIndex('product', ['title'], {
-      type: 'FULLTEXT',
-    });
+    await queryInterface.sequelize.query(
+      'ALTER TABLE product ADD FULLTEXT INDEX `product_title`(title) WITH PARSER NGRAM;'
+    );
     await queryInterface.addIndex('reserve', ['tag']);
     await queryInterface.addIndex('user', ['email']);
     await queryInterface.addIndex('user', ['name']);


### PR DESCRIPTION
mysql提供了一個ngram全文分析器來支援中文，在創建full text index時，就需要設定
因此更改sql migration file